### PR TITLE
Various minor fixes

### DIFF
--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -1,4 +1,3 @@
-#include "unicode/ucnv.h"
 #include "benchmark.h"
 #include "simdutf.h"
 

--- a/benchmarks/src/benchmark.h
+++ b/benchmarks/src/benchmark.h
@@ -22,6 +22,7 @@
 #include <unicode/uconfig.h>
 #include <unicode/platform.h>
 #include <unicode/unistr.h>
+#include <unicode/ucnv.h>
 #endif
 
 #if ICONV_AVAILABLE

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -25,7 +25,8 @@
 #include "scalar/utf8.h"
 #include "scalar/utf16.h"
 #include "scalar/latin1.h"
-
+#include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
+#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
 
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
@@ -56,9 +57,8 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(const char*
 }
 
 simdutf_warn_unused size_t implementation::utf16_length_from_latin1(const char * input, size_t length) const noexcept {
-  //return length;
-    return scalar::latin1::utf16_length_from_latin1(input,length);
-  }
+  return scalar::latin1::utf16_length_from_latin1(input,length);
+}
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf16_to_latin1::convert_valid<endianness::BIG>(buf, len, latin1_output);
@@ -71,8 +71,6 @@ simdutf_warn_unused result implementation::convert_utf16be_to_latin1_with_errors
 simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf16_to_latin1::convert<endianness::BIG>(buf, len, latin1_output);
 }
-
-
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf16_to_latin1::convert_valid<endianness::LITTLE>(buf, len, latin1_output);
@@ -88,7 +86,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(const char1
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf16(const char16_t * input, size_t length) const noexcept {
   return scalar::utf16::latin1_length_from_utf16(input,length);
-  }
+}
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(const char * buf, size_t len, char* utf8_output) const noexcept {
   return scalar::latin1_to_utf8::convert(buf,len,utf8_output);
@@ -118,98 +116,95 @@ simdutf_warn_unused size_t implementation::convert_valid_utf32_to_latin1(const c
   return scalar::utf32_to_latin1::convert_valid(buf, len, latin1_output);
 }
 
-
 simdutf_warn_unused result implementation::convert_utf32_to_latin1_with_errors(const char32_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf32_to_latin1::convert_with_errors(buf, len, latin1_output);
 }
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf32(const char32_t * input, size_t length) const noexcept {
   return length;
-  }
+}
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(const char * buf, size_t len, char32_t* utf32_output) const noexcept {
   return scalar::latin1_to_utf32::convert(buf,len,utf32_output);
 }
 simdutf_warn_unused size_t implementation::utf32_length_from_latin1(const char * input, size_t length) const noexcept {
-  //return length;
-    return scalar::latin1::utf32_length_from_latin1(input,length);
-  }
+  return scalar::latin1::utf32_length_from_latin1(input,length);
+}
 
 simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * input, size_t length) const noexcept {
   return scalar::latin1::utf8_length_from_latin1(input,length);
-  }
-
+}
 
 simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t len) const noexcept {
-    return scalar::utf8::validate(buf, len);
+  return scalar::utf8::validate(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_utf8_with_errors(const char *buf, size_t len) const noexcept {
-    return scalar::utf8::validate_with_errors(buf, len);
+  return scalar::utf8::validate_with_errors(buf, len);
 }
 
 simdutf_warn_unused bool implementation::validate_ascii(const char *buf, size_t len) const noexcept {
-    return scalar::ascii::validate(buf, len);
+  return scalar::ascii::validate(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_ascii_with_errors(const char *buf, size_t len) const noexcept {
-    return scalar::ascii::validate_with_errors(buf, len);
+  return scalar::ascii::validate_with_errors(buf, len);
 }
 
 simdutf_warn_unused bool implementation::validate_utf16le(const char16_t *buf, size_t len) const noexcept {
-    return scalar::utf16::validate<endianness::LITTLE>(buf, len);
+  return scalar::utf16::validate<endianness::LITTLE>(buf, len);
 }
 
 simdutf_warn_unused bool implementation::validate_utf16be(const char16_t *buf, size_t len) const noexcept {
-    return scalar::utf16::validate<endianness::BIG>(buf, len);
+  return scalar::utf16::validate<endianness::BIG>(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_utf16le_with_errors(const char16_t *buf, size_t len) const noexcept {
-    return scalar::utf16::validate_with_errors<endianness::LITTLE>(buf, len);
+  return scalar::utf16::validate_with_errors<endianness::LITTLE>(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_utf16be_with_errors(const char16_t *buf, size_t len) const noexcept {
-    return scalar::utf16::validate_with_errors<endianness::BIG>(buf, len);
+  return scalar::utf16::validate_with_errors<endianness::BIG>(buf, len);
 }
 
 simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, size_t len) const noexcept {
-    return scalar::utf32::validate(buf, len);
+  return scalar::utf32::validate(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_utf32_with_errors(const char32_t *buf, size_t len) const noexcept {
-    return scalar::utf32::validate_with_errors(buf, len);
+  return scalar::utf32::validate_with_errors(buf, len);
 }
 
 simdutf_warn_unused size_t implementation::convert_utf8_to_utf16le(const char* buf, size_t len, char16_t* utf16_output) const noexcept {
-   return scalar::utf8_to_utf16::convert<endianness::LITTLE>(buf, len, utf16_output);
+  return scalar::utf8_to_utf16::convert<endianness::LITTLE>(buf, len, utf16_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_utf8_to_utf16be(const char* buf, size_t len, char16_t* utf16_output) const noexcept {
-   return scalar::utf8_to_utf16::convert<endianness::BIG>(buf, len, utf16_output);
+  return scalar::utf8_to_utf16::convert<endianness::BIG>(buf, len, utf16_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf8_to_utf16le_with_errors(const char* buf, size_t len, char16_t* utf16_output) const noexcept {
-   return scalar::utf8_to_utf16::convert_with_errors<endianness::LITTLE>(buf, len, utf16_output);
+  return scalar::utf8_to_utf16::convert_with_errors<endianness::LITTLE>(buf, len, utf16_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf8_to_utf16be_with_errors(const char* buf, size_t len, char16_t* utf16_output) const noexcept {
-   return scalar::utf8_to_utf16::convert_with_errors<endianness::BIG>(buf, len, utf16_output);
+  return scalar::utf8_to_utf16::convert_with_errors<endianness::BIG>(buf, len, utf16_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf16le(const char* buf, size_t len, char16_t* utf16_output) const noexcept {
-   return scalar::utf8_to_utf16::convert_valid<endianness::LITTLE>(buf, len, utf16_output);
+  return scalar::utf8_to_utf16::convert_valid<endianness::LITTLE>(buf, len, utf16_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf16be(const char* buf, size_t len, char16_t* utf16_output) const noexcept {
-   return scalar::utf8_to_utf16::convert_valid<endianness::BIG>(buf, len, utf16_output);
+  return scalar::utf8_to_utf16::convert_valid<endianness::BIG>(buf, len, utf16_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_utf8_to_utf32(const char* buf, size_t len, char32_t* utf32_output) const noexcept {
-   return scalar::utf8_to_utf32::convert(buf, len, utf32_output);
+  return scalar::utf8_to_utf32::convert(buf, len, utf32_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf8_to_utf32_with_errors(const char* buf, size_t len, char32_t* utf32_output) const noexcept {
-   return scalar::utf8_to_utf32::convert_with_errors(buf, len, utf32_output);
+  return scalar::utf8_to_utf32::convert_with_errors(buf, len, utf32_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(const char* input, size_t size,

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -7,6 +7,8 @@
 #include "scalar/utf8.h"
 #include "scalar/utf16.h"
 #include "scalar/latin1.h"
+#include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
+#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
 
 #include "simdutf/haswell/begin.h"
 namespace simdutf {
@@ -80,9 +82,8 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(const char*
 }
 
 simdutf_warn_unused size_t implementation::utf16_length_from_latin1(const char * input, size_t length) const noexcept {
-  //return length;
-    return scalar::latin1::utf16_length_from_latin1(input,length);
-  }
+  return scalar::latin1::utf16_length_from_latin1(input,length);
+}
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf16_to_latin1::convert_valid<endianness::BIG>(buf, len, latin1_output);
@@ -104,14 +105,13 @@ simdutf_warn_unused result implementation::convert_utf16le_to_latin1_with_errors
   return scalar::utf16_to_latin1::convert_with_errors<endianness::LITTLE>(buf, len, latin1_output);
 }
 
-
 simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf16_to_latin1::convert<endianness::LITTLE>(buf, len, latin1_output);
 }
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf16(const char16_t * input, size_t length) const noexcept {
   return scalar::utf16::latin1_length_from_utf16(input,length);
-  }
+}
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(const char * buf, size_t len, char* utf8_output) const noexcept {
   return scalar::latin1_to_utf8::convert(buf,len,utf8_output);
@@ -120,8 +120,6 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(const char * b
 simdutf_warn_unused size_t implementation::latin1_length_from_utf8(const char* buf, size_t len) const noexcept {
   return scalar::utf8::latin1_length_from_utf8(buf,len);
 }
-
-
 
 simdutf_warn_unused size_t implementation::convert_utf8_to_latin1(const char* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf8_to_latin1::convert(buf, len, latin1_output);

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -7,6 +7,8 @@
 #include "scalar/utf8.h"
 #include "scalar/utf16.h"
 #include "scalar/latin1.h"
+#include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
+#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
 
 #include "simdutf/icelake/begin.h"
 namespace simdutf {
@@ -44,9 +46,8 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(const char*
 }
 
 simdutf_warn_unused size_t implementation::utf16_length_from_latin1(const char * input, size_t length) const noexcept {
-  //return length;
-    return scalar::latin1::utf16_length_from_latin1(input,length);
-  }
+  return scalar::latin1::utf16_length_from_latin1(input,length);
+}
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf16_to_latin1::convert_valid<endianness::BIG>(buf, len, latin1_output);
@@ -56,11 +57,9 @@ simdutf_warn_unused result implementation::convert_utf16be_to_latin1_with_errors
   return scalar::utf16_to_latin1::convert_with_errors<endianness::BIG>(buf, len, latin1_output);
 }
 
-
 simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf16_to_latin1::convert<endianness::BIG>(buf, len, latin1_output);
 }
-
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf16_to_latin1::convert_valid<endianness::LITTLE>(buf, len, latin1_output);
@@ -70,14 +69,13 @@ simdutf_warn_unused result implementation::convert_utf16le_to_latin1_with_errors
   return scalar::utf16_to_latin1::convert_with_errors<endianness::LITTLE>(buf, len, latin1_output);
 }
 
-
 simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf16_to_latin1::convert<endianness::LITTLE>(buf, len, latin1_output);
 }
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf16(const char16_t * input, size_t length) const noexcept {
   return scalar::utf16::latin1_length_from_utf16(input,length);
-  }
+}
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(const char * buf, size_t len, char* utf8_output) const noexcept {
   return scalar::latin1_to_utf8::convert(buf,len,utf8_output);
@@ -86,8 +84,6 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(const char * b
 simdutf_warn_unused size_t implementation::convert_utf8_to_latin1(const char* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf8_to_latin1::convert(buf, len, latin1_output);
 }
-
-
 
 simdutf_warn_unused size_t implementation::convert_valid_utf8_to_latin1(const char* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf8_to_latin1::convert_valid(buf, len, latin1_output);
@@ -98,17 +94,12 @@ simdutf_warn_unused result implementation::convert_utf8_to_latin1_with_errors(co
 }
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf8(const char * input, size_t length) const noexcept {
-  //return length;
   return scalar::utf8::latin1_length_from_utf8(input,length);
-  }
-
-
+}
 
 simdutf_warn_unused size_t implementation::convert_utf32_to_latin1(const char32_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf32_to_latin1::convert(buf,len,latin1_output);
 }
-
-
 
 simdutf_warn_unused size_t implementation::convert_valid_utf32_to_latin1(const char32_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf32_to_latin1::convert_valid(buf,len,latin1_output);
@@ -120,19 +111,18 @@ simdutf_warn_unused result implementation::convert_utf32_to_latin1_with_errors(c
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf32(const char32_t * input, size_t length) const noexcept {
   return length;
-  }
+}
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(const char * buf, size_t len, char32_t* utf32_output) const noexcept {
   return scalar::latin1_to_utf32::convert(buf,len,utf32_output);
 }
 simdutf_warn_unused size_t implementation::utf32_length_from_latin1(const char * input, size_t length) const noexcept {
-  //return length;
-    return scalar::latin1::utf32_length_from_latin1(input,length);
-  }
+  return scalar::latin1::utf32_length_from_latin1(input,length);
+}
+
 simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * input, size_t length) const noexcept {
   return scalar::latin1::utf8_length_from_latin1(input,length);
-  }
-
+}
 
 simdutf_warn_unused int
 implementation::detect_encodings(const char *input,

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -1,6 +1,8 @@
 #include "scalar/utf8.h"
 #include "scalar/utf16.h"
 #include "scalar/latin1.h"
+#include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
+#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
 
 #include "scalar/utf16_to_utf8/valid_utf16_to_utf8.h"
 #include "scalar/utf16_to_utf8/utf16_to_utf8.h"

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -157,21 +157,19 @@ simdutf_warn_unused result implementation::convert_utf32_to_latin1_with_errors(c
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf32(const char32_t * input, size_t length) const noexcept {
   return length;
-  }
+}
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(const char * buf, size_t len, char32_t* utf32_output) const noexcept {
   return scalar::latin1_to_utf32::convert(buf,len,utf32_output);
 }
+
 simdutf_warn_unused size_t implementation::utf32_length_from_latin1(const char * input, size_t length) const noexcept {
   return length;
-  }
+}
 
 simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * input, size_t length) const noexcept {
   return scalar::latin1::utf8_length_from_latin1(input,length);
-  }
-
-
-
+}
 
 simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t len) const noexcept {
   return westmere::utf8_validation::generic_validate_utf8(buf, len);


### PR DESCRIPTION
I made a few minor changes. 

- [x]  Somehow the code would not build without additional headers. I added them.
- [x] There was an unguarded ICU header.
- [x] I fixed a few formatting issues. Though the simdutf project does not have compulsory formatting, we try to keep the code nice.

Here are my performance numbers:

```
$ ./build/benchmarks/benchmark -P convert_utf8_to_latin1  -F unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt 
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 67.1
testcases: 1
input detected as UTF8
current system detected as icelake
===========================
convert_utf8_to_latin1+haswell, input size: 86940, iterations: 3000, dataset: unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
   3.004 ins/byte,    0.627 cycle/byte,    3.190 GB/s (1.6 %),     2.001 GHz,    4.789 ins/cycle 
   3.004 ins/char,    0.627 cycle/char,    3.190 Gc/s (1.6 %)     1.00 byte/char 
convert_utf8_to_latin1+icelake, input size: 86940, iterations: 3000, dataset: unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
   3.004 ins/byte,    0.627 cycle/byte,    3.189 GB/s (1.5 %),     2.001 GHz,    4.787 ins/cycle 
   3.004 ins/char,    0.627 cycle/char,    3.189 Gc/s (1.5 %)     1.00 byte/char 
convert_utf8_to_latin1+iconv, input size: 86940, iterations: 3000, dataset: unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
  30.025 ins/byte,    5.254 cycle/byte,    0.608 GB/s (21.2 %),     3.194 GHz,    5.715 ins/cycle 
  30.025 ins/char,    5.254 cycle/char,    0.608 Gc/s (21.2 %)     1.00 byte/char 
WARNING: Measurements are noisy, try increasing iteration count (-I).
convert_utf8_to_latin1+icu, input size: 86940, iterations: 3000, dataset: unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
  17.171 ins/byte,    3.043 cycle/byte,    0.939 GB/s (0.5 %),     2.858 GHz,    5.643 ins/cycle 
  17.171 ins/char,    3.043 cycle/char,    0.939 Gc/s (0.5 %)     1.00 byte/char 
convert_utf8_to_latin1+westmere, input size: 86940, iterations: 3000, dataset: unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
   3.004 ins/byte,    0.629 cycle/byte,    5.091 GB/s (0.9 %),     3.202 GHz,    4.776 ins/cycle 
   3.004 ins/char,    0.629 cycle/char,    5.091 Gc/s (0.9 %)     1.00 byte/char 
convert_utf8_to_latin1_with_errors+haswell, input size: 86940, iterations: 3000, dataset: unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
   3.004 ins/byte,    0.627 cycle/byte,    5.106 GB/s (0.8 %),     3.202 GHz,    4.790 ins/cycle 
   3.004 ins/char,    0.627 cycle/char,    5.106 Gc/s (0.8 %)     1.00 byte/char 
convert_utf8_to_latin1_with_errors+icelake, input size: 86940, iterations: 3000, dataset: unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
   3.004 ins/byte,    0.627 cycle/byte,    5.106 GB/s (0.8 %),     3.202 GHz,    4.790 ins/cycle 
   3.004 ins/char,    0.627 cycle/char,    5.106 Gc/s (0.8 %)     1.00 byte/char 
convert_utf8_to_latin1_with_errors+westmere, input size: 86940, iterations: 3000, dataset: unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
   3.004 ins/byte,    0.628 cycle/byte,    5.099 GB/s (0.6 %),     3.202 GHz,    4.784 ins/cycle 
   3.004 ins/char,    0.628 cycle/char,    5.099 Gc/s (0.6 %)     1.00 byte/char 
```

I have not investigated further but if I try to process non-ASCII files, I get errors as part of the benchmarking...

```
git clone git@github.com:lemire/unicode_lipsum.git
./build/benchmarks/benchmark -P latin -F unicode_lipsum/wikipedia_mars/esperanto.latin1.txt 
```

This does not work.