### PR TITLE
Various fixes on latin1

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ are fast and non-validating.
 
  /**
    * Return the number of bytes that this Latin1 string would require in UTF-8 format.
-   *   
+   *
    * @param input         the Latin1 string to convert
    * @param length        the length of the string bytes
    * @return the number of bytes required to encode the Latin1 string as UTF-8
@@ -575,7 +575,7 @@ are fast and non-validating.
    * This function does not validate the input.
    *
    * This function is not BOM-aware.
-   * 
+   *
    * @param input         the UTF-8 string to convert
    * @param length        the length of the string in byte
    * @return the number of bytes required to encode the UTF-8 string as Latin1
@@ -599,9 +599,9 @@ are fast and non-validating.
    * Compute the number of bytes that this UTF-32 string would require in Latin1 format.
    *
    * This function does not validate the input.
-   * 
+   *
    * This function is not BOM-aware.
-   *    
+   *
    * @param input         the UTF-32 string to convert
    * @param length        the length of the string in 4-byte words (char32_t)
    * @return the number of bytes required to encode the UTF-32 string as Latin1
@@ -761,7 +761,7 @@ scenario where you expect the input to be valid most of the time.
    * @return the number of written char; 0 if conversion is not possible
    */
   simdutf_warn_unused size_t convert_latin1_to_utf8(const char * input, size_t length, char* utf8_output) noexcept;
-  
+
 
     /**
    * Convert possibly Latin1 string into UTF-16LE string.
@@ -1072,7 +1072,7 @@ further investigation.
    * Convert possibly broken UTF-16LE string into Latin1 string.
    *
    * During the conversion also validation of the input string is done.
-   * This function is suitable to work with inputs from untrusted sources.   
+   * This function is suitable to work with inputs from untrusted sources.
    * This function is not BOM-aware.
    *
    * @param input         the UTF-16LE string to convert
@@ -1086,7 +1086,7 @@ further investigation.
    * Convert possibly broken UTF-16BE string into Latin1 string.
    *
    * During the conversion also validation of the input string is done.
-   * This function is suitable to work with inputs from untrusted sources.   
+   * This function is suitable to work with inputs from untrusted sources.
    * This function is not BOM-aware.
    *
    * @param input         the UTF-16BE string to convert
@@ -1095,7 +1095,7 @@ further investigation.
    * @return a result pair struct with an error code and either the position of the error if any or the number of char written if successful.
    */
   simdutf_warn_unused result convert_utf16be_to_latin1_with_errors(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
-  
+
 
 /**
  * Using native endianness; Convert possibly broken UTF-8 string into UTF-16

--- a/benchmarks/src/CMakeLists.txt
+++ b/benchmarks/src/CMakeLists.txt
@@ -56,6 +56,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT MINGW)
   target_link_libraries(simdutf_benchmarks_benchmark PUBLIC stdc++fs)
 endif()
 
-target_link_libraries(simdutf_benchmarks_benchmark PUBLIC simdutf simdutf::tests::helpers) 
+target_link_libraries(simdutf_benchmarks_benchmark PUBLIC simdutf simdutf::tests::helpers)
 
 add_library(simdutf::benchmarks::benchmark ALIAS simdutf_benchmarks_benchmark)

--- a/benchmarks/src/apple_arm_events.h
+++ b/benchmarks/src/apple_arm_events.h
@@ -1112,7 +1112,7 @@ struct AppleEvents {
         u64 val = counters_1[idx] - counters_0[idx];
         printf("%14s: %llu\n", alias->alias, val);
     }*/
-    return performance_counters{
+    return performance_counters {
         counters_0[counter_map[0]], counters_0[counter_map[3]],
         counters_0[counter_map[2]], counters_0[counter_map[1]]};
   }

--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -228,7 +228,7 @@ Benchmark::Benchmark(std::vector<input::Testcase>&& testcases)
         std::string name = "convert_utf32_to_latin1+iconv";
         known_procedures.insert(name);
         expected_input_encoding.insert(std::make_pair(name,std::set<simdutf::encoding_type>({simdutf::encoding_type::UTF32_LE})));
-    } 
+    }
 #endif
 #ifdef INOUE2008
     {
@@ -840,7 +840,6 @@ void Benchmark::run_convert_utf8_to_latin1(const simdutf::implementation& implem
     auto proc = [&implementation, data, size, &output_buffer, &sink]() {
         sink = implementation.convert_utf8_to_latin1(data, size, output_buffer.get());
     };
-    count_events(proc, iterations); // warming up!
     const auto result = count_events(proc, iterations);
     if((sink == 0) && (size != 0) && (iterations > 0)) { std::cerr << "The output is zero which might indicate an error.\n"; }
     size_t char_count = get_active_implementation()->count_utf8(data, size);
@@ -1029,7 +1028,7 @@ void Benchmark::run_convert_latin1_to_utf8_icu(size_t iterations) {
 
     if (memcmp(target.get(), output_buffer.get(), sink) != 0) {
         std::cerr << "The output data does not match.\n";
-    } 
+    }
 
     print_summary(result, size, char_count);
 }
@@ -1066,7 +1065,7 @@ void Benchmark::run_convert_latin1_to_utf16_icu(size_t iterations) {
     size_t char_count = size;
     std::unique_ptr<char16_t[]> output_buffer{new char16_t[size]};
     size_t expected = get_active_implementation()->convert_latin1_to_utf16le(data, size, output_buffer.get()); //expected char16_t units
-    if(2 * expected != sink) { std::cerr << "The number of utf16le words does not match.\n"; 
+    if(2 * expected != sink) { std::cerr << "The number of utf16le words does not match.\n";
                             std::cerr << "Expected: " << 2*expected + 1<< ", Sink: " << sink << std::endl; // print values
                         }
 
@@ -1077,7 +1076,7 @@ void Benchmark::run_convert_latin1_to_utf16_icu(size_t iterations) {
         for(size_t i=0; i<20; i++) { std::cout << std::hex << static_cast<int>(target.get()[i]) << " "; }
         std::cout << "\nFirst 20 characters of output buffer: ";
         for(size_t i=0; i<20; i++) { std::cout << std::hex << static_cast<int>(output_buffer[i]) << " "; }
-    
+
          // compare last 20 characters and print their hexadecimal values
         size_t num_chars = sink / sizeof(UChar);
         size_t start = num_chars < 20 ? 0 : num_chars - 20;
@@ -1085,7 +1084,7 @@ void Benchmark::run_convert_latin1_to_utf16_icu(size_t iterations) {
         for(size_t i=start; i<num_chars; i++) { std::cout << std::hex << static_cast<int>(target.get()[i]) << " "; }
         std::cout << "\nLast 20 characters of output buffer: ";
         for(size_t i=start; i<num_chars; i++) { std::cout << std::hex << static_cast<int>(output_buffer[i]) << " "; }
-    } 
+    }
 
     print_summary(result, size, char_count);
 }
@@ -1096,7 +1095,7 @@ void Benchmark::run_convert_latin1_to_utf32_icu(size_t iterations) {
     volatile size_t sink{0};
 
     std::unique_ptr<char[]> target;
-  
+
     auto proc = [&target, data, size, &sink]() {
         UErrorCode status = U_ZERO_ERROR;
 
@@ -1138,14 +1137,14 @@ void Benchmark::run_convert_latin1_to_utf32_icu(size_t iterations) {
                             std::cout << "Expected: " << expected << ", Sink: " << sink << std::endl; // print values
                            }
 
-    if(memcmp(target.get(), output_buffer.get(), sink) != 0) {  
+    if(memcmp(target.get(), output_buffer.get(), sink) != 0) {
         std::cerr << "The output data does not match.\n";
         // compare first 20 characters and print their hexadecimal values
         std::cout << "First 20 characters of target data: ";
         for(size_t i=0; i<20; i++) { std::cout << std::hex << static_cast<int>(target.get()[i]) << " "; }
         std::cout << "\nFirst 20 characters of output buffer: ";
         for(size_t i=0; i<20; i++) { std::cout << std::hex << static_cast<int>(output_buffer[i]) << " "; }
-    
+
          // compare last 20 characters and print their hexadecimal values
         size_t num_chars = sink / sizeof(UChar);
         size_t start = num_chars < 20 ? 0 : num_chars - 20;
@@ -1153,7 +1152,7 @@ void Benchmark::run_convert_latin1_to_utf32_icu(size_t iterations) {
         for(size_t i=start; i<num_chars; i++) { std::cout << std::hex << static_cast<int>(target.get()[i]) << " "; }
         std::cout << "\nLast 20 characters of output buffer: ";
         for(size_t i=start; i<num_chars; i++) { std::cout << std::hex << static_cast<int>(output_buffer[i]) << " "; }
-    } 
+    }
 
     print_summary(result, size, char_count);
 }
@@ -1211,10 +1210,10 @@ void Benchmark::run_convert_utf8_to_latin1_icu(size_t iterations) {
         for(size_t i=0; i<20; i++) { std::cout << std::hex << static_cast<int>(target.get()[i]) << " "; }
         std::cout << "\nFirst 20 characters of output buffer: ";
         for(size_t i=0; i<20; i++) { std::cout << std::hex << static_cast<int>(output_buffer[i]) << " "; }
-    } 
+    }
 
     print_summary(result, size, char_count);
-} 
+}
 
 
 void Benchmark::run_convert_utf8_to_utf16_icu(size_t iterations) {
@@ -1285,7 +1284,7 @@ void Benchmark::run_convert_utf16_to_latin1_icu(size_t iterations) {
 
         sink = ucnv_fromUChars(conv, targetStart, targetCapacity, reinterpret_cast<const UChar*>(data), size, &status);
         assert(U_SUCCESS(status));
-        
+
         // Clean up
         ucnv_close(conv);
     };
@@ -1307,7 +1306,7 @@ void Benchmark::run_convert_utf16_to_latin1_icu(size_t iterations) {
         for(size_t i=0; i<20; i++) { std::cout << std::hex << static_cast<int>(target.get()[i]) << " "; }
         std::cout << "\nFirst 20 characters of output buffer: ";
         for(size_t i=0; i<20; i++) { std::cout << std::hex << static_cast<int>(output_buffer[i]) << " "; }
-    } 
+    }
 
     print_summary(result, size, char_count);
 }
@@ -1341,7 +1340,7 @@ void Benchmark::run_convert_utf32_to_latin1_icu(size_t iterations) {
 
         const char* sourceStart = reinterpret_cast<const char*>(data);
         const char* sourceEnd = sourceStart + size * sizeof(char32_t);
-        
+
         // Convert from UTF-32 to Latin1
         ucnv_convertEx(latin1conv, utf32conv, &targetStart, targetStart + targetCapacity, &sourceStart, sourceEnd, nullptr, nullptr, nullptr, nullptr, true, true, &status);
         assert(U_SUCCESS(status));
@@ -1371,7 +1370,7 @@ void Benchmark::run_convert_utf32_to_latin1_icu(size_t iterations) {
         for(size_t i=0; i<20; i++) { std::cout << std::hex << static_cast<int>(target.get()[i]) << " "; }
         std::cout << "\nFirst 20 characters of output buffer: ";
         for(size_t i=0; i<20; i++) { std::cout << std::hex << static_cast<int>(output_buffer[i]) << " "; }
-    } 
+    }
 
     print_summary(result, size, char_count);
 }
@@ -1412,7 +1411,7 @@ void Benchmark::run_convert_utf32_to_latin1_icu(size_t iterations) {
     if((sink == 0) && (size != 0) && (iterations > 0)) { std::cerr << "The output is zero which might indicate an error.\n"; }
     size_t char_count = size;
     print_summary(result, size, char_count);
-} 
+}
 
 void Benchmark::run_convert_latin1_to_utf16_iconv(size_t iterations) {
     iconv_t cv = iconv_open("UTF-16", "ISO-8859-1");
@@ -1509,7 +1508,7 @@ void Benchmark::run_convert_utf8_to_latin1_iconv(size_t iterations) {
             sink = (sizeof(uint8_t) * size - outbytes) / sizeof(char);;
         }
 
-        
+
     };
     count_events(proc, iterations); // warming up!
     const auto result = count_events(proc, iterations);
@@ -2183,7 +2182,7 @@ void Benchmark::run_convert_utf16_to_latin1(const simdutf::implementation& imple
         printf(" Running function on truncated input.\n");
     }
 
-    size /= 2;    
+    size /= 2;
     std::unique_ptr<char[]> output_buffer{new char[size]};
     volatile size_t sink{0};
     auto proc = [&implementation, data, size, &output_buffer, &sink]() {
@@ -2206,7 +2205,7 @@ void Benchmark::run_convert_utf16_to_latin1_with_errors(const simdutf::implement
         printf(" Running function on truncated input.\n");
     }
 
-    size /= 2;    
+    size /= 2;
     std::unique_ptr<char[]> output_buffer{new char[size]};
     volatile bool sink{false};
     auto proc = [&implementation, data, size, &output_buffer, &sink]() {
@@ -2230,7 +2229,7 @@ void Benchmark::run_convert_valid_utf16_to_latin1(const simdutf::implementation&
         printf(" Running function on truncated input.\n");
     }
 
-    size /= 2;    
+    size /= 2;
     std::unique_ptr<char[]> output_buffer{new char[size]};
     volatile size_t sink{0};
     auto proc = [&implementation, data, size, &output_buffer, &sink]() {

--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -75,7 +75,7 @@ Benchmark::Benchmark(std::vector<input::Testcase>&& testcases)
     : BenchmarkBase(std::move(testcases)) {
 
     // the std::set<simdutf::encoding_type> value represents the *expected* encoding.
-    std::vector<std::pair<std::string,std::set<simdutf::encoding_type>>> implemented_functions{
+    std::vector<std::pair<std::string,std::set<simdutf::encoding_type>>> implemented_functions {
         {"validate_utf8", {simdutf::encoding_type::UTF8}},
         {"validate_utf8_with_errors", {simdutf::encoding_type::UTF8}},
         {"validate_utf16", {simdutf::encoding_type::UTF16_LE}},
@@ -132,7 +132,6 @@ Benchmark::Benchmark(std::vector<input::Testcase>&& testcases)
         {"convert_valid_utf32_to_utf16", {simdutf::encoding_type::UTF32_LE}},
 
         {"detect_encodings", {simdutf::encoding_type::UTF8, simdutf::encoding_type::UTF16_LE, simdutf::encoding_type::UTF32_LE}}
-
     };
 
     for (const auto& implementation: simdutf::get_available_implementations()) {

--- a/benchmarks/src/benchmark.h
+++ b/benchmarks/src/benchmark.h
@@ -113,7 +113,7 @@ namespace simdutf::benchmarks {
         void run_convert_utf8_to_utf16_icu(size_t iterations);
         void run_convert_utf16_to_utf8_icu(size_t iterations);
         void run_convert_utf16_to_latin1_icu(size_t iterations);
-        void run_convert_utf32_to_latin1_icu(size_t iterations); 
+        void run_convert_utf32_to_latin1_icu(size_t iterations);
 #endif
 #if ICONV_AVAILABLE
         void run_convert_latin1_to_utf8_iconv(size_t iterations);

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -217,7 +217,7 @@ simdutf_warn_unused result validate_utf32_with_errors(const char32_t *buf, size_
    * @return the number of written char; 0 if conversion is not possible
    */
   simdutf_warn_unused size_t convert_latin1_to_utf8(const char * input, size_t length, char* utf8_output) noexcept;
-  
+
 
     /**
    * Convert possibly Latin1 string into UTF-16LE string.
@@ -393,7 +393,7 @@ simdutf_warn_unused result convert_utf8_to_utf32_with_errors(const char * input,
    * This function assumes that the input string is valid UTF-8.
    *
    * This function is not BOM-aware.
-   *    
+   *
    * @param input         the UTF-8 string to convert
    * @param length        the length of the string in bytes
    * @param latin1_output  the pointer to buffer that can hold conversion result
@@ -453,7 +453,7 @@ simdutf_warn_unused size_t convert_valid_utf8_to_utf32(const char * input, size_
 
  /**
    * Return the number of bytes that this Latin1 string would require in UTF-8 format.
-   *   
+   *
    * @param input         the Latin1 string to convert
    * @param length        the length of the string bytes
    * @return the number of bytes required to encode the Latin1 string as UTF-8
@@ -466,7 +466,7 @@ simdutf_warn_unused size_t convert_valid_utf8_to_utf32(const char * input, size_
    * This function does not validate the input.
    *
    * This function is not BOM-aware.
-   * 
+   *
    * @param input         the UTF-8 string to convert
    * @param length        the length of the string in byte
    * @return the number of bytes required to encode the UTF-8 string as Latin1
@@ -582,7 +582,7 @@ simdutf_warn_unused size_t convert_utf16be_to_utf8(const char16_t * input, size_
    * Convert possibly broken UTF-16LE string into Latin1 string.
    *
    * During the conversion also validation of the input string is done.
-   * This function is suitable to work with inputs from untrusted sources.   
+   * This function is suitable to work with inputs from untrusted sources.
    * This function is not BOM-aware.
    *
    * @param input         the UTF-16LE string to convert
@@ -596,7 +596,7 @@ simdutf_warn_unused size_t convert_utf16be_to_utf8(const char16_t * input, size_
    * Convert possibly broken UTF-16BE string into Latin1 string.
    *
    * During the conversion also validation of the input string is done.
-   * This function is suitable to work with inputs from untrusted sources.   
+   * This function is suitable to work with inputs from untrusted sources.
    * This function is not BOM-aware.
    *
    * @param input         the UTF-16BE string to convert
@@ -605,7 +605,7 @@ simdutf_warn_unused size_t convert_utf16be_to_utf8(const char16_t * input, size_
    * @return a result pair struct with an error code and either the position of the error if any or the number of char written if successful.
    */
   simdutf_warn_unused result convert_utf16be_to_latin1_with_errors(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
-  
+
 
 /**
  * Using native endianness; Convert possibly broken UTF-16 string into UTF-8 string and stop on error.
@@ -1470,7 +1470,7 @@ public:
    * @return the number of written char; 0 if conversion is not possible
    */
   simdutf_warn_unused virtual size_t convert_latin1_to_utf8(const char * input, size_t length, char* utf8_output) const noexcept = 0;
-  
+
 
     /**
    * Convert possibly Latin1 string into UTF-16LE string.
@@ -1540,7 +1540,7 @@ public:
    * This function assumes that the input string is valid UTF-8.
    *
    * This function is not BOM-aware.
-   *    
+   *
    * @param input         the UTF-8 string to convert
    * @param length        the length of the string in bytes
    * @param latin1_output  the pointer to buffer that can hold conversion result
@@ -1721,7 +1721,7 @@ public:
    * Convert possibly broken UTF-16LE string into Latin1 string.
    *
    * During the conversion also validation of the input string is done.
-   * This function is suitable to work with inputs from untrusted sources.   
+   * This function is suitable to work with inputs from untrusted sources.
    * This function is not BOM-aware.
    *
    * @param input         the UTF-16LE string to convert
@@ -1735,7 +1735,7 @@ public:
    * Convert possibly broken UTF-16BE string into Latin1 string.
    *
    * During the conversion also validation of the input string is done.
-   * This function is suitable to work with inputs from untrusted sources.   
+   * This function is suitable to work with inputs from untrusted sources.
    * This function is not BOM-aware.
    *
    * @param input         the UTF-16BE string to convert
@@ -2180,7 +2180,7 @@ public:
 
  /**
    * Return the number of bytes that this Latin1 string would require in UTF-8 format.
-   *   
+   *
    * @param input         the Latin1 string to convert
    * @param length        the length of the string bytes
    * @return the number of bytes required to encode the Latin1 string as UTF-8
@@ -2202,7 +2202,7 @@ public:
    * Compute the number of bytes that this UTF-32 string would require in Latin1 format.
    *
    * This function does not validate the input.
-   *    
+   *
    * @param input         the UTF-32 string to convert
    * @param length        the length of the string in 4-byte words (char32_t)
    * @return the number of bytes required to encode the UTF-32 string as Latin1
@@ -2255,7 +2255,7 @@ public:
    * @return the number of bytes required to encode the UTF-32 string as Latin1
    */
     simdutf_warn_unused virtual size_t utf32_length_from_latin1(const char * input, size_t length) const noexcept = 0;
-  
+
   /*
    * Compute the number of bytes that this UTF-16LE string would require in UTF-32 format.
    *

--- a/src/arm64/arm_convert_utf8_to_utf16.cpp
+++ b/src/arm64/arm_convert_utf8_to_utf16.cpp
@@ -44,7 +44,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     uint8x16_t ascii = vandq_u8(perm, vreinterpretq_u8_u16(vmovq_n_u16(0x7f)));
     uint8x16_t highbyte = vandq_u8(perm, vreinterpretq_u8_u16(vmovq_n_u16(0x1f00)));
     uint8x16_t composed = vorrq_u8(ascii, vreinterpretq_u8_u16(vshrq_n_u16(vreinterpretq_u16_u8(highbyte), 2)));
-    if (!match_system(big_endian)) composed = vqtbl1q_u8(composed, swap);
+    if (!match_system(big_endian)) { composed = vqtbl1q_u8(composed, swap); }
     vst1q_u8(reinterpret_cast<uint8_t*>(utf16_output), composed);
     utf16_output += 8; // We wrote 16 bytes, 8 code points.
     return 16;
@@ -69,7 +69,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     uint32x4_t composed =
         vorrq_u32(vorrq_u32(vreinterpretq_u32_u8(ascii), vreinterpretq_u32_u8(middlebyte_shifted)), highbyte_shifted);
     uint16x8_t composed_repacked = vmovn_high_u32(vmovn_u32(composed), composed);
-    if (!match_system(big_endian)) composed_repacked = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(composed_repacked), swap));
+    if (!match_system(big_endian)) { composed_repacked = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(composed_repacked), swap)); }
     vst1q_u16(reinterpret_cast<uint16_t*>(utf16_output), composed_repacked);
     utf16_output += 4;
     return 12;
@@ -92,7 +92,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     uint8x16_t ascii = vandq_u8(perm, vreinterpretq_u8_u16(vmovq_n_u16(0x7f)));
     uint8x16_t highbyte = vandq_u8(perm, vreinterpretq_u8_u16(vmovq_n_u16(0x1f00)));
     uint8x16_t composed = vorrq_u8(ascii, vreinterpretq_u8_u16(vshrq_n_u16(vreinterpretq_u16_u8(highbyte), 2)));
-    if (!match_system(big_endian)) composed = vqtbl1q_u8(composed, swap);
+    if (!match_system(big_endian)) { composed = vqtbl1q_u8(composed, swap); }
     vst1q_u8(reinterpret_cast<uint8_t*>(utf16_output), composed);
     utf16_output += 6; // We wrote 12 bytes, 6 code points.
   } else if (idx < 145) {
@@ -110,7 +110,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     uint32x4_t composed =
         vorrq_u32(vorrq_u32(vreinterpretq_u32_u8(ascii), vreinterpretq_u32_u8(middlebyte_shifted)), highbyte_shifted);
     uint16x8_t composed_repacked = vmovn_high_u32(vmovn_u32(composed), composed);
-    if (!match_system(big_endian)) composed_repacked = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(composed_repacked), swap));
+    if (!match_system(big_endian)) { composed_repacked = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(composed_repacked), swap)); }
     vst1q_u16(reinterpret_cast<uint16_t*>(utf16_output), composed_repacked);
     utf16_output += 4;
   } else if (idx < 209) {

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,5 +1,5 @@
 namespace simdutf {
-  
+
   simdutf_really_inline result::result() : error{error_code::SUCCESS}, count{0} {};
 
   simdutf_really_inline result::result(error_code _err, size_t _pos) : error{_err}, count{_pos} {};

--- a/src/generic/utf16.h
+++ b/src/generic/utf16.h
@@ -10,7 +10,7 @@ simdutf_really_inline size_t count_code_points(const char16_t* in, size_t size) 
     size_t count = 0;
     for(;pos + 32 <= size; pos += 32) {
       simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
-      if (!match_system(big_endian)) input.swap_bytes();
+      if (!match_system(big_endian)) { input.swap_bytes(); }
       uint64_t not_pair = input.not_in_range(0xDC00, 0xDFFF);
       count += count_ones(not_pair) / 2;
     }
@@ -24,7 +24,7 @@ simdutf_really_inline size_t utf8_length_from_utf16(const char16_t* in, size_t s
     // This algorithm could no doubt be improved!
     for(;pos + 32 <= size; pos += 32) {
       simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
-      if (!match_system(big_endian)) input.swap_bytes();
+      if (!match_system(big_endian)) { input.swap_bytes(); }
       uint64_t ascii_mask = input.lteq(0x7F);
       uint64_t twobyte_mask = input.lteq(0x7FF);
       uint64_t not_pair_mask = input.not_in_range(0xD800, 0xDFFF);

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -157,14 +157,14 @@ public:
     return set_best()->convert_utf8_to_latin1(buf, len,latin1_output);
   }
 
-  simdutf_warn_unused result convert_utf8_to_latin1_with_errors(const char* buf, size_t len, char* latin1_output) const noexcept  final override{
+  simdutf_warn_unused result convert_utf8_to_latin1_with_errors(const char* buf, size_t len, char* latin1_output) const noexcept  final override {
   return set_best()->convert_utf8_to_latin1_with_errors(buf, len, latin1_output);
   }
 
   simdutf_warn_unused size_t convert_valid_utf8_to_latin1(const char * buf, size_t len, char* latin1_output) const noexcept final override {
     return set_best()->convert_valid_utf8_to_latin1(buf, len,latin1_output);
   }
-  
+
   simdutf_warn_unused size_t convert_utf8_to_utf16le(const char * buf, size_t len, char16_t* utf16_output) const noexcept final override {
     return set_best()->convert_utf8_to_utf16le(buf, len, utf16_output);
   }
@@ -204,7 +204,7 @@ public:
    simdutf_warn_unused size_t convert_utf16le_to_latin1(const char16_t * buf, size_t len, char* latin1_output) const noexcept final override {
     return set_best()->convert_utf16le_to_latin1(buf, len, latin1_output);
   }
- 
+
      simdutf_warn_unused size_t convert_utf16be_to_latin1(const char16_t * buf, size_t len, char* latin1_output) const noexcept final override {
     return set_best()->convert_utf16be_to_latin1(buf, len, latin1_output);
   }
@@ -337,19 +337,17 @@ public:
     return set_best()->count_utf8(buf, len);
   }
 
-
   simdutf_warn_unused size_t latin1_length_from_utf8(const char * buf, size_t len) const noexcept override {
     return set_best()->latin1_length_from_utf8(buf, len);
-  }  
+  }
 
-    simdutf_warn_unused size_t latin1_length_from_utf16(const char16_t * buf, size_t len) const noexcept override {
+  simdutf_warn_unused size_t latin1_length_from_utf16(const char16_t * buf, size_t len) const noexcept override {
     return set_best()->latin1_length_from_utf16(buf, len);
   }
 
-    simdutf_warn_unused size_t latin1_length_from_utf32(const char32_t * buf, size_t len) const noexcept override {
+  simdutf_warn_unused size_t latin1_length_from_utf32(const char32_t * buf, size_t len) const noexcept override {
     return set_best()->latin1_length_from_utf32(buf, len);
   }
- 
 
   simdutf_warn_unused size_t utf8_length_from_latin1(const char * buf, size_t len) const noexcept override {
     return set_best()->utf8_length_from_latin1(buf, len);
@@ -366,7 +364,7 @@ public:
   simdutf_warn_unused size_t utf16_length_from_latin1(const char * buf, size_t len) const noexcept override {
     return set_best()->utf16_length_from_latin1(buf, len);
   }
- 
+
   simdutf_warn_unused size_t utf32_length_from_latin1(const char * buf, size_t len) const noexcept override {
     return set_best()->utf32_length_from_latin1(buf, len);
   }
@@ -477,7 +475,7 @@ public:
     return result(error_code::OTHER, 0);
   }
 
- simdutf_warn_unused size_t convert_latin1_to_utf8(const char*, size_t, char*) const noexcept final override {
+  simdutf_warn_unused size_t convert_latin1_to_utf8(const char*, size_t, char*) const noexcept final override {
     return 0;
   }
 
@@ -497,7 +495,7 @@ public:
     return 0;
   }
 
-  simdutf_warn_unused result convert_utf8_to_latin1_with_errors(const char* buf, size_t len, char* latin1_output) const noexcept final override{
+  simdutf_warn_unused result convert_utf8_to_latin1_with_errors(const char*, size_t, char*) const noexcept final override {
     return result(error_code::OTHER, 0);
   }
 

--- a/src/scalar/latin1.h
+++ b/src/scalar/latin1.h
@@ -6,21 +6,21 @@ namespace scalar {
 namespace {
 namespace latin1 {
 
-inline size_t utf32_length_from_latin1(const char* buf, size_t len) {
+inline size_t utf32_length_from_latin1(const char* , size_t len) {
   // We are not BOM aware.
-  return len; // a utf32 will always represent 1 latin1 character
+  return len; // a utf32 unit will always represent 1 latin1 character
 }
 
 inline size_t utf8_length_from_latin1(const char *buf, size_t len) {
   const uint8_t * c = reinterpret_cast<const uint8_t *>(buf);
   size_t answer = 0;
   for(size_t i = 0; i<len; i++) {
-    if((c[i]>>7)) { answer++;}
+    if((c[i]>>7)) { answer++; }
   }
   return answer + len;
 }
 
-inline size_t utf16_length_from_latin1(const char *c, size_t len) {
+inline size_t utf16_length_from_latin1(const char *, size_t len) {
   return len;
 }
 

--- a/src/scalar/latin1_to_utf16/latin1_to_utf16.h
+++ b/src/scalar/latin1_to_utf16/latin1_to_utf16.h
@@ -8,33 +8,30 @@ namespace latin1_to_utf16 {
 
 template <endianness big_endian>
 inline size_t convert(const char* buf, size_t len, char16_t* utf16_output) {
-    const uint8_t* data = reinterpret_cast<const uint8_t*>(buf);
-    size_t pos = 0;
-    char16_t* start{ utf16_output };
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(buf);
+  size_t pos = 0;
+  char16_t* start{ utf16_output };
 
-    while (pos < len) {
-        uint16_t word = uint16_t(data[pos]); // extend Latin-1 char to 16-bit Unicode code point
-        if (word > 0xFF){return 0;};
-        *utf16_output++ = char16_t(match_system(big_endian) ? word : utf16::swap_bytes(word));
-        pos++;
-    }
+  while (pos < len) {
+    uint16_t word = uint16_t(data[pos]); // extend Latin-1 char to 16-bit Unicode code point
+    *utf16_output++ = char16_t(match_system(big_endian) ? word : utf16::swap_bytes(word));
+    pos++;
+  }
 
-    return utf16_output - start;
+  return utf16_output - start;
 }
 
 template <endianness big_endian>
 inline result convert_with_errors(const char* buf, size_t len, char16_t* utf16_output) {
-    const uint8_t* data = reinterpret_cast<const uint8_t*>(buf);
-    size_t pos = 0;
-    char16_t* start{ utf16_output };
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(buf);
+  size_t pos = 0;
+  char16_t* start{ utf16_output };
 
-    while (pos < len) {
-        uint16_t word = uint16_t(data[pos]); // extend Latin-1 char to 16-bit Unicode code point
-        if (word > 0xFF){return result(error_code::TOO_LARGE, pos);};
-
-        *utf16_output++ = char16_t(match_system(big_endian) ? word : utf16::swap_bytes(word));
-        pos++;
-    }
+  while (pos < len) {
+    uint16_t word = uint16_t(data[pos]); // extend Latin-1 char to 16-bit Unicode code point
+    *utf16_output++ = char16_t(match_system(big_endian) ? word : utf16::swap_bytes(word));
+    pos++;
+  }
 
   return result(error_code::SUCCESS, utf16_output - start);
 }

--- a/src/scalar/latin1_to_utf32/latin1_to_utf32.h
+++ b/src/scalar/latin1_to_utf32/latin1_to_utf32.h
@@ -10,20 +10,18 @@ namespace latin1_to_utf32 {
 inline size_t convert(const char *buf, size_t len, char32_t *utf32_output) {
   const unsigned char *data = reinterpret_cast<const unsigned char *>(buf);
   char32_t* start{utf32_output};
-  
   for (size_t i = 0; i < len; i++) {
-    *utf32_output++ = (char32_t)data[i]; 
-  } 
+    *utf32_output++ = (char32_t)data[i];
+  }
   return utf32_output - start;
 }
 
 inline result convert_with_errors(const char32_t *buf, size_t len, char32_t *utf32_output) {
-    const uint32_t *data = reinterpret_cast<const uint32_t *>(buf);
-     char32_t* start{utf32_output};
-
-    for (size_t i = 0; i < len; i++) {
-        *utf32_output++ = (char32_t)data[i]; 
-    } 
+  const uint32_t *data = reinterpret_cast<const uint32_t *>(buf);
+  char32_t* start{utf32_output};
+  for (size_t i = 0; i < len; i++) {
+    *utf32_output++ = (char32_t)data[i];
+  }
   return result(error_code::SUCCESS, utf32_output - start);
 }
 

--- a/src/scalar/latin1_to_utf8/latin1_to_utf8.h
+++ b/src/scalar/latin1_to_utf8/latin1_to_utf8.h
@@ -11,16 +11,14 @@ inline size_t convert(const char* buf, size_t len, char* utf8_output) {
   size_t pos = 0;
   char* start{utf8_output};
   while (pos < len) {
-
-
     // try to convert the next block of 16 ASCII bytes
     if (pos + 16 <= len) { // if it is safe to read 16 more bytes, check that they are ascii
       uint64_t v1;
       ::memcpy(&v1, data + pos, sizeof(uint64_t));
       uint64_t v2;
       ::memcpy(&v2, data + pos + sizeof(uint64_t), sizeof(uint64_t));
-      uint64_t v{v1 | v2}; //We're only interested in these bits: 1000 1000 1000 1000, so it makes sense to concatenate everything
-      if ((v & 0x8080808080808080) == 0) { //if NONE of these are set, e.g. all of them are zero, then everything is ASCII
+      uint64_t v{v1 | v2}; // We are only interested in these bits: 1000 1000 1000 1000, so it makes sense to concatenate everything
+      if ((v & 0x8080808080808080) == 0) { // if NONE of these are set, e.g. all of them are zero, then everything is ASCII
         size_t final_pos = pos + 16;
         while(pos < final_pos) {
           *utf8_output++ = char(buf[pos]);
@@ -31,17 +29,16 @@ inline size_t convert(const char* buf, size_t len, char* utf8_output) {
     }
 
     unsigned char byte = data[pos];
-    if((byte & 0x80)==0) { //if ASCII
+    if((byte & 0x80) == 0) { // if ASCII
       // will generate one UTF-8 bytes
       *utf8_output++ = char(byte);
       pos++;
     } else {
       // will generate two UTF-8 bytes
-      *utf8_output++ = char((byte>>6) | 0b11000000); //
-      *utf8_output++ = char((byte & 0b111111) | 0b10000000); //
+      *utf8_output++ = char((byte>>6) | 0b11000000);
+      *utf8_output++ = char((byte & 0b111111) | 0b10000000);
       pos++;
-    } 
-
+    }
   }
   return utf8_output - start;
 }

--- a/src/scalar/utf16.h
+++ b/src/scalar/utf16.h
@@ -96,7 +96,7 @@ inline size_t utf32_length_from_utf16(const char16_t* buf, size_t len) {
 }
 
 
-inline size_t latin1_length_from_utf16(const char16_t* buf, size_t len) {
+inline size_t latin1_length_from_utf16(const char16_t*, size_t len) {
   return len;
 }
 

--- a/src/scalar/utf16_to_latin1/utf16_to_latin1.h
+++ b/src/scalar/utf16_to_latin1/utf16_to_latin1.h
@@ -17,7 +17,7 @@ inline size_t convert(const char16_t* buf, size_t len, char* latin_output) {
   while (pos < len) {
     word = !match_system(big_endian) ? utf16::swap_bytes(data[pos]) : data[pos];
     too_large |= word;
-    *latin_output++ = char(word);
+    *latin_output++ = char(word & 0xFF);
     pos++;
   }
   if((too_large & 0xFF00) != 0) { return 0; }
@@ -29,13 +29,33 @@ inline result convert_with_errors(const char16_t* buf, size_t len, char* latin_o
  const uint16_t *data = reinterpret_cast<const uint16_t *>(buf);
   size_t pos = 0;
   char* start{latin_output};
-  uint16_t word = 0;
+  uint16_t word;
 
   while (pos < len) {
-    word = !match_system(big_endian) ? utf16::swap_bytes(data[pos]) : data[pos];
+    if (pos + 16 <= len) { // if it is safe to read 32 more bytes, check that they are Latin1
+      uint64_t v1, v2, v3, v4;
+      ::memcpy(&v1, data + pos, sizeof(uint64_t));
+      ::memcpy(&v2, data + pos + 4, sizeof(uint64_t));
+      ::memcpy(&v3, data + pos + 8, sizeof(uint64_t));
+      ::memcpy(&v4, data + pos  + 12, sizeof(uint64_t));
 
+      if (!match_system(big_endian)) { v1 = (v1 >> 8) | (v1 << (64 - 8)); }
+      if (!match_system(big_endian)) { v2 = (v2 >> 8) | (v2 << (64 - 8)); }
+      if (!match_system(big_endian)) { v3 = (v3 >> 8) | (v3 << (64 - 8)); }
+      if (!match_system(big_endian)) { v4 = (v1 >> 8) | (v4 << (64 - 8)); }
+
+      if (((v1 | v2 | v3 | v4) & 0xFF00FF00FF00FF00) == 0) {
+        size_t final_pos = pos + 16;
+        while(pos < final_pos) {
+          *latin_output++ = !match_system(big_endian) ? char(utf16::swap_bytes(data[pos])) : char(data[pos]);
+          pos++;
+        }
+        continue;
+      }
+    }
+    word = !match_system(big_endian) ? utf16::swap_bytes(data[pos]) : data[pos];
     if((word & 0xFF00 ) == 0) {
-        *latin_output++ = char(word);
+        *latin_output++ = char(word & 0xFF);
         pos++;
     } else { return result(error_code::TOO_LARGE, pos); }
   }

--- a/src/scalar/utf16_to_latin1/utf16_to_latin1.h
+++ b/src/scalar/utf16_to_latin1/utf16_to_latin1.h
@@ -12,15 +12,15 @@ inline size_t convert(const char16_t* buf, size_t len, char* latin_output) {
   size_t pos = 0;
   char* start{latin_output};
   uint16_t word = 0;
+  uint16_t too_large = 0;
 
   while (pos < len) {
     word = !match_system(big_endian) ? utf16::swap_bytes(data[pos]) : data[pos];
-
-    if((word & 0xFF00 ) == 0) { 
-        *latin_output++ = char(word);
-        pos++;
-    } else { return 0;}
+    too_large |= word;
+    *latin_output++ = char(word);
+    pos++;
   }
+  if((too_large & 0xFF00) != 0) { return 0; }
   return latin_output - start;
 }
 
@@ -29,16 +29,15 @@ inline result convert_with_errors(const char16_t* buf, size_t len, char* latin_o
  const uint16_t *data = reinterpret_cast<const uint16_t *>(buf);
   size_t pos = 0;
   char* start{latin_output};
-  uint16_t word = 0; 
-  
+  uint16_t word = 0;
 
   while (pos < len) {
     word = !match_system(big_endian) ? utf16::swap_bytes(data[pos]) : data[pos];
 
-    if((word & 0xFF00 ) == 0) { 
+    if((word & 0xFF00 ) == 0) {
         *latin_output++ = char(word);
         pos++;
-    } else { return result(error_code::TOO_LARGE, pos);}
+    } else { return result(error_code::TOO_LARGE, pos); }
   }
   return result(error_code::SUCCESS,latin_output - start);
 }

--- a/src/scalar/utf16_to_latin1/valid_utf16_to_latin1.h
+++ b/src/scalar/utf16_to_latin1/valid_utf16_to_latin1.h
@@ -14,9 +14,9 @@ inline size_t convert_valid(const char16_t* buf, size_t len, char* latin_output)
   uint16_t word = 0;
 
   while (pos < len) {
-        word = !match_system(big_endian) ? utf16::swap_bytes(data[pos]) : data[pos];
-        *latin_output++ = char(word);
-        pos++;
+    word = !match_system(big_endian) ? utf16::swap_bytes(data[pos]) : data[pos];
+    *latin_output++ = char(word);
+    pos++;
   }
 
   return latin_output - start;

--- a/src/scalar/utf16_to_latin1/valid_utf16_to_latin1.h
+++ b/src/scalar/utf16_to_latin1/valid_utf16_to_latin1.h
@@ -17,8 +17,8 @@ inline size_t convert_valid(const char16_t* buf, size_t len, char* latin_output)
         word = !match_system(big_endian) ? utf16::swap_bytes(data[pos]) : data[pos];
         *latin_output++ = char(word);
         pos++;
-    } 
-  
+  }
+
   return latin_output - start;
 }
 

--- a/src/scalar/utf16_to_utf8/utf16_to_utf8.h
+++ b/src/scalar/utf16_to_utf8/utf16_to_utf8.h
@@ -16,7 +16,7 @@ inline size_t convert(const char16_t* buf, size_t len, char* utf8_output) {
     if (pos + 4 <= len) { // if it is safe to read 8 more bytes, check that they are ascii
       uint64_t v;
       ::memcpy(&v, data + pos, sizeof(uint64_t));
-      if (!match_system(big_endian)) v = (v >> 8) | (v << (64 - 8));
+      if (!match_system(big_endian)) { v = (v >> 8) | (v << (64 - 8)); }
       if ((v & 0xFF80FF80FF80FF80) == 0) {
         size_t final_pos = pos + 4;
         while(pos < final_pos) {

--- a/src/scalar/utf16_to_utf8/valid_utf16_to_utf8.h
+++ b/src/scalar/utf16_to_utf8/valid_utf16_to_utf8.h
@@ -16,7 +16,7 @@ inline size_t convert_valid(const char16_t* buf, size_t len, char* utf8_output) 
     if (pos + 4 <= len) { // if it is safe to read 8 more bytes, check that they are ascii
       uint64_t v;
       ::memcpy(&v, data + pos, sizeof(uint64_t));
-      if (!match_system(big_endian)) v = (v >> 8) | (v << (64 - 8));
+      if (!match_system(big_endian)) { v = (v >> 8) | (v << (64 - 8)); }
       if ((v & 0xFF80FF80FF80FF80) == 0) {
         size_t final_pos = pos + 4;
         while(pos < final_pos) {

--- a/src/scalar/utf32.h
+++ b/src/scalar/utf32.h
@@ -63,9 +63,9 @@ inline size_t utf16_length_from_utf32(const char32_t* buf, size_t len) {
   return counter;
 }
 
-inline size_t latin1_length_from_utf32(const char32_t* buf, size_t len) {
+inline size_t latin1_length_from_utf32(const char32_t*, size_t len) {
   // We are not BOM aware.
-  return len; // a utf32 will always represent 1 latin1 character
+  return len; // a utf32 codepoint will always represent 1 latin1 character
 }
 
 

--- a/src/scalar/utf32_to_latin1/utf32_to_latin1.h
+++ b/src/scalar/utf32_to_latin1/utf32_to_latin1.h
@@ -27,10 +27,7 @@ inline result convert_with_errors(const char32_t *buf, size_t len, char *latin1_
   const uint32_t *data = reinterpret_cast<const uint32_t *>(buf);
   char* start{latin1_output};
   size_t pos = 0;
-  uint32_t utf32_char;
-
   while (pos < len) {
-    utf32_char = (uint32_t)data[pos];
     if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are Latin1
       uint64_t v;
       ::memcpy(&v, data + pos, sizeof(uint64_t));
@@ -41,6 +38,7 @@ inline result convert_with_errors(const char32_t *buf, size_t len, char *latin1_
         continue;
       }
     }
+    uint32_t utf32_char = data[pos];
     if ((utf32_char & 0xFFFFFF00) == 0) { // Check if the character can be represented in Latin-1
       *latin1_output++ = (char)(utf32_char & 0xFF);
       pos++;

--- a/src/scalar/utf32_to_latin1/utf32_to_latin1.h
+++ b/src/scalar/utf32_to_latin1/utf32_to_latin1.h
@@ -7,60 +7,46 @@ namespace {
 namespace utf32_to_latin1 {
 
 inline size_t convert(const char32_t *buf, size_t len, char *latin1_output) {
-    const uint32_t *data = reinterpret_cast<const uint32_t *>(buf);
-    char* start = latin1_output;
-    uint32_t utf32_char;
-    size_t pos = 0;
+  const uint32_t *data = reinterpret_cast<const uint32_t *>(buf);
+  char* start = latin1_output;
+  uint32_t utf32_char;
+  size_t pos = 0;
+  uint32_t too_large = 0;
 
-    while (pos < len) {
-        utf32_char = (uint32_t)data[pos];
-
-        if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are Latin1
-            uint64_t v;
-            ::memcpy(&v, data + pos, sizeof(uint64_t));
-            if ((v & 0xFFFFFF80FFFFFF80) == 0) {
-                *latin1_output++ = char(buf[pos]);
-                *latin1_output++ = char(buf[pos+1]);
-            pos += 2;
-            continue;
-            }
-        } 
-
-        if ((utf32_char & 0xFFFFFF00) == 0) { // Check if the character can be represented in Latin-1
-            *latin1_output++ = (char)(utf32_char & 0xFF);
-            pos++;
-        } else {
-            return 0;
-        }
-    }
-    return latin1_output - start;
+  while (pos < len) {
+    utf32_char = (uint32_t)data[pos];
+    too_large |= utf32_char;
+    *latin1_output++ = (char)(utf32_char & 0xFF);
+    pos++;
+  }
+  if((too_large & 0xFFFFFF00) != 0) { return 0; }
+  return latin1_output - start;
 }
 
 inline result convert_with_errors(const char32_t *buf, size_t len, char *latin1_output) {
-    const uint32_t *data = reinterpret_cast<const uint32_t *>(buf);
-    char* start{latin1_output};
-    size_t pos = 0;
-    uint32_t utf32_char;
+  const uint32_t *data = reinterpret_cast<const uint32_t *>(buf);
+  char* start{latin1_output};
+  size_t pos = 0;
+  uint32_t utf32_char;
 
-    while (pos < len) {
-        utf32_char = (uint32_t)data[pos]; 
-        if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are Latin1
-            uint64_t v;
-            ::memcpy(&v, data + pos, sizeof(uint64_t));
-            if ((v & 0xFFFFFF80FFFFFF80) == 0) {
-                *latin1_output++ = char(buf[pos]);
-                *latin1_output++ = char(buf[pos+1]);
-            pos += 2;
-            continue;
-            }
-        } 
-        if ((utf32_char & 0xFFFFFF00) == 0){ // Check if the character can be represented in Latin-1
-            *latin1_output++ = (char)(utf32_char & 0xFF);
-            pos++;
-        } else {return result(error_code::TOO_LARGE, pos);};
+  while (pos < len) {
+    utf32_char = (uint32_t)data[pos];
+    if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are Latin1
+      uint64_t v;
+      ::memcpy(&v, data + pos, sizeof(uint64_t));
+      if ((v & 0xFFFFFF00FFFFFF00) == 0) {
+        *latin1_output++ = char(buf[pos]);
+        *latin1_output++ = char(buf[pos+1]);
+        pos += 2;
+        continue;
+      }
     }
+    if ((utf32_char & 0xFFFFFF00) == 0) { // Check if the character can be represented in Latin-1
+      *latin1_output++ = (char)(utf32_char & 0xFF);
+      pos++;
+    } else { return result(error_code::TOO_LARGE, pos); };
+  }
   return result(error_code::SUCCESS, latin1_output - start);
-
 }
 
 } // utf32_to_latin1 namespace

--- a/src/scalar/utf32_to_latin1/valid_utf32_to_latin1.h
+++ b/src/scalar/utf32_to_latin1/valid_utf32_to_latin1.h
@@ -7,29 +7,29 @@ namespace {
 namespace utf32_to_latin1 {
 
 inline size_t convert_valid(const char32_t *buf, size_t len, char *latin1_output) {
-    const uint32_t *data = reinterpret_cast<const uint32_t *>(buf);
-    char* start = latin1_output;
-    uint32_t utf32_char;
-    size_t pos = 0;
+  const uint32_t *data = reinterpret_cast<const uint32_t *>(buf);
+  char* start = latin1_output;
+  uint32_t utf32_char;
+  size_t pos = 0;
 
-    while (pos < len) {
-        utf32_char = (uint32_t)data[pos];
-        
-        if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are Latin1
-            uint64_t v;
-            ::memcpy(&v, data + pos, sizeof(uint64_t));
-            if ((v & 0xFFFFFF80FFFFFF80) == 0) {
-                *latin1_output++ = char(buf[pos]);
-                *latin1_output++ = char(buf[pos+1]);
-            pos += 2;
-            continue;
-            }
-        } 
-        *latin1_output++ = (char)(utf32_char & 0xFF);
-        pos++;
+  while (pos < len) {
+    utf32_char = (uint32_t)data[pos];
 
+    if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are Latin1
+      uint64_t v;
+      ::memcpy(&v, data + pos, sizeof(uint64_t));
+      if ((v & 0xFFFFFF00FFFFFF00) == 0) {
+        *latin1_output++ = char(buf[pos]);
+        *latin1_output++ = char(buf[pos+1]);
+        pos += 2;
+        continue;
+      }
     }
-    return latin1_output - start;
+    *latin1_output++ = (char)(utf32_char & 0xFF);
+    pos++;
+
+  }
+  return latin1_output - start;
 }
 
 

--- a/src/scalar/utf32_to_latin1/valid_utf32_to_latin1.h
+++ b/src/scalar/utf32_to_latin1/valid_utf32_to_latin1.h
@@ -13,20 +13,20 @@ inline size_t convert_valid(const char32_t *buf, size_t len, char *latin1_output
   size_t pos = 0;
 
   while (pos < len) {
-    utf32_char = (uint32_t)data[pos];
+  utf32_char = (uint32_t)data[pos];
 
-    if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are Latin1
+  if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are Latin1
       uint64_t v;
       ::memcpy(&v, data + pos, sizeof(uint64_t));
       if ((v & 0xFFFFFF00FFFFFF00) == 0) {
-        *latin1_output++ = char(buf[pos]);
-        *latin1_output++ = char(buf[pos+1]);
-        pos += 2;
-        continue;
-      }
+      *latin1_output++ = char(buf[pos]);
+      *latin1_output++ = char(buf[pos+1]);
+      pos += 2;
+      continue;
     }
-    *latin1_output++ = (char)(utf32_char & 0xFF);
-    pos++;
+  }
+  *latin1_output++ = (char)(utf32_char & 0xFF);
+  pos++;
 
   }
   return latin1_output - start;

--- a/src/scalar/utf8_to_latin1/utf8_to_latin1.h
+++ b/src/scalar/utf8_to_latin1/utf8_to_latin1.h
@@ -19,8 +19,8 @@ inline size_t convert(const char* buf, size_t len, char* latin_output) {
       ::memcpy(&v1, data + pos, sizeof(uint64_t));
       uint64_t v2;
       ::memcpy(&v2, data + pos + sizeof(uint64_t), sizeof(uint64_t));
-      uint64_t v{v1 | v2}; //We're only interested in these bits: 1000 1000 1000 1000 .... etc
-      if ((v & 0x8080808080808080) == 0) { //if NONE of these are set, e.g. all of them are zero, then everything is ASCII
+      uint64_t v{v1 | v2}; // We are only interested in these bits: 1000 1000 1000 1000 .... etc
+      if ((v & 0x8080808080808080) == 0) { // if NONE of these are set, e.g. all of them are zero, then everything is ASCII
         size_t final_pos = pos + 16;
         while(pos < final_pos) {
           *latin_output++ = char(buf[pos]);
@@ -30,22 +30,23 @@ inline size_t convert(const char* buf, size_t len, char* latin_output) {
       }
     }
 
-    //suppose it isn't an all ASCII byte
+    // suppose it is not an all ASCII byte sequence
     uint8_t leading_byte = data[pos]; // leading byte
     if (leading_byte < 0b10000000) {
       // converting one ASCII byte !!!
       *latin_output++ = char(leading_byte);
       pos++;
-    } else if ((leading_byte & 0b11100000) == 0b11000000) {//the first three bits indicate:
+    } else if ((leading_byte & 0b11100000) == 0b11000000) { // the first three bits indicate:
       // We have a two-byte UTF-8
       if(pos + 1 >= len) {
          return 0; } // minimal bound checking
-      if ((data[pos + 1] & 0b11000000) != 0b10000000) { return 0; }// checks if the next byte is a valid continuation byte in UTF-8. A valid continuation byte starts with 10.
+      if ((data[pos + 1] & 0b11000000) != 0b10000000) { return 0; } // checks if the next byte is a valid continuation byte in UTF-8. A valid continuation byte starts with 10.
       // range check -
-      uint32_t code_point = (leading_byte & 0b00011111) << 6 | (data[pos + 1] & 0b00111111);//assembles the Unicode code point from the two bytes. It does this by discarding the leading 110 and 10 bits from the two bytes, shifting the remaining bits of the first byte, and then combining the results with a bitwise OR operation.
-      if ( 0xFF < code_point) { 
-            return 0; } //We only care about the range 129-255 which is Non-ASCII latin1 characters
-      *latin_output++ = char(code_point); 
+      uint32_t code_point = (leading_byte & 0b00011111) << 6 | (data[pos + 1] & 0b00111111); // assembles the Unicode code point from the two bytes. It does this by discarding the leading 110 and 10 bits from the two bytes, shifting the remaining bits of the first byte, and then combining the results with a bitwise OR operation.
+      if ( 0xFF < code_point) {
+        return 0; // We only care about the range 129-255 which is Non-ASCII latin1 characters
+      }
+      *latin_output++ = char(code_point);
       pos += 2;
     } else {
       return 0;
@@ -66,8 +67,8 @@ inline result convert_with_errors(const char* buf, size_t len, char* latin_outpu
       ::memcpy(&v1, data + pos, sizeof(uint64_t));
       uint64_t v2;
       ::memcpy(&v2, data + pos + sizeof(uint64_t), sizeof(uint64_t));
-      uint64_t v{v1 | v2}; //We're only interested in these bits: 1000 1000 1000 1000...etc
-      if ((v & 0x8080808080808080) == 0) { //if NONE of these are set, e.g. all of them are zero, then everything is ASCII
+      uint64_t v{v1 | v2}; // We are only interested in these bits: 1000 1000 1000 1000...etc
+      if ((v & 0x8080808080808080) == 0) { // if NONE of these are set, e.g. all of them are zero, then everything is ASCII
         size_t final_pos = pos + 16;
         while(pos < final_pos) {
           *latin_output++ = char(buf[pos]);
@@ -76,26 +77,26 @@ inline result convert_with_errors(const char* buf, size_t len, char* latin_outpu
         continue;
       }
     }
-    //suppose it isn't all ASCII bytes
+    // suppose it is not an all ASCII byte sequence
     uint8_t leading_byte = data[pos]; // leading byte
     if (leading_byte < 0b10000000) {
       // converting one ASCII byte !!!
       *latin_output++ = char(leading_byte);
       pos++;
-    } else if ((leading_byte & 0b11100000) == 0b11000000) {//the first three bits indicate:
+    } else if ((leading_byte & 0b11100000) == 0b11000000) { // the first three bits indicate:
       // We have a two-byte UTF-8
-      if(pos + 1 >= len) { 
+      if(pos + 1 >= len) {
         return result(error_code::TOO_SHORT, pos); } // minimal bound checking
-      if ((data[pos + 1] & 0b11000000) != 0b10000000) { 
-        return result(error_code::TOO_SHORT, pos); }// checks if the next byte is a valid continuation byte in UTF-8. A valid continuation byte starts with 10.
+      if ((data[pos + 1] & 0b11000000) != 0b10000000) {
+        return result(error_code::TOO_SHORT, pos); } // checks if the next byte is a valid continuation byte in UTF-8. A valid continuation byte starts with 10.
       // range check -
-      uint32_t code_point = (leading_byte & 0b00011111) << 6 | (data[pos + 1] & 0b00111111);//assembles the Unicode code point from the two bytes. It does this by discarding the leading 110 and 10 bits from the two bytes, shifting the remaining bits of the first byte, and then combining the results with a bitwise OR operation.
-      if (code_point < 0x80) { 
+      uint32_t code_point = (leading_byte & 0b00011111) << 6 | (data[pos + 1] & 0b00111111); // assembles the Unicode code point from the two bytes. It does this by discarding the leading 110 and 10 bits from the two bytes, shifting the remaining bits of the first byte, and then combining the results with a bitwise OR operation.
+      if (code_point < 0x80) {
         return result(error_code::OVERLONG, pos); }
-      if ( 0xFF < code_point) { 
-          return result(error_code::TOO_LARGE, pos); 
-          } //We only care about the range 129-255 which is Non-ASCII latin1 characters
-      *latin_output++ = char(code_point); 
+      if ( 0xFF < code_point) {
+          return result(error_code::TOO_LARGE, pos);
+          } // We only care about the range 129-255 which is Non-ASCII latin1 characters
+      *latin_output++ = char(code_point);
       pos += 2;
     } else if ((leading_byte & 0b11110000) == 0b11100000) {
       // We have a three-byte UTF-8
@@ -105,11 +106,11 @@ inline result convert_with_errors(const char* buf, size_t len, char* latin_outpu
       return result(error_code::TOO_LARGE, pos);
     } else {
       // we either have too many continuation bytes or an invalid leading byte
-      if ((leading_byte & 0b11000000) == 0b10000000) { 
+      if ((leading_byte & 0b11000000) == 0b10000000) {
                 return result(error_code::TOO_LONG, pos); }
 
       return result(error_code::HEADER_BITS, pos);
-      
+
     }
   }
   return result(error_code::SUCCESS, latin_output - start);

--- a/src/scalar/utf8_to_latin1/valid_utf8_to_latin1.h
+++ b/src/scalar/utf8_to_latin1/valid_utf8_to_latin1.h
@@ -19,8 +19,8 @@ inline size_t convert_valid(const char* buf, size_t len, char* latin_output) {
       ::memcpy(&v1, data + pos, sizeof(uint64_t));
       uint64_t v2;
       ::memcpy(&v2, data + pos + sizeof(uint64_t), sizeof(uint64_t));
-      uint64_t v{v1 | v2}; //We're only interested in these bits: 1000 1000 1000 1000, so it makes sense to concatenate everything
-      if ((v & 0x8080808080808080) == 0) { //if NONE of these are set, e.g. all of them are zero, then everything is ASCII
+      uint64_t v{v1 | v2}; // We are only interested in these bits: 1000 1000 1000 1000, so it makes sense to concatenate everything
+      if ((v & 0x8080808080808080) == 0) { // if NONE of these are set, e.g. all of them are zero, then everything is ASCII
         size_t final_pos = pos + 16;
         while(pos < final_pos) {
           *latin_output++ = char(buf[pos]);
@@ -30,19 +30,19 @@ inline size_t convert_valid(const char* buf, size_t len, char* latin_output) {
       }
     }
 
-    //suppose it isn't an all ASCII byte
+    // suppose it is not an all ASCII byte sequence
     uint8_t leading_byte = data[pos]; // leading byte
     if (leading_byte < 0b10000000) {
       // converting one ASCII byte !!!
       *latin_output++ = char(leading_byte);
       pos++;
-    } else if ((leading_byte & 0b11100000) == 0b11000000) {//the first three bits indicate:
+    } else if ((leading_byte & 0b11100000) == 0b11000000) { // the first three bits indicate:
       // We have a two-byte UTF-8
       if(pos + 1 >= len) { break; } // minimal bound checking
-      if ((data[pos + 1] & 0b11000000) != 0b10000000) { return 0; }// checks if the next byte is a valid continuation byte in UTF-8. A valid continuation byte starts with 10.
+      if ((data[pos + 1] & 0b11000000) != 0b10000000) { return 0; } // checks if the next byte is a valid continuation byte in UTF-8. A valid continuation byte starts with 10.
       // range check -
-      uint32_t code_point = (leading_byte & 0b00011111) << 6 | (data[pos + 1] & 0b00111111);//assembles the Unicode code point from the two bytes. It does this by discarding the leading 110 and 10 bits from the two bytes, shifting the remaining bits of the first byte, and then combining the results with a bitwise OR operation.
-      *latin_output++ = char(code_point); 
+      uint32_t code_point = (leading_byte & 0b00011111) << 6 | (data[pos + 1] & 0b00111111); // assembles the Unicode code point from the two bytes. It does this by discarding the leading 110 and 10 bits from the two bytes, shifting the remaining bits of the first byte, and then combining the results with a bitwise OR operation.
+      *latin_output++ = char(code_point);
       pos += 2;
     } else {
       // we may have a continuation but we do not do error checking

--- a/tests/convert_latin1_to_utf16le_tests.cpp
+++ b/tests/convert_latin1_to_utf16le_tests.cpp
@@ -21,8 +21,7 @@ TEST(convert_all_latin) {
   for(size_t trial = 0; trial < trials; trial ++) {
     if ((trial % 100) == 0) { std::cout << "."; std::cout.flush(); }
     // range for 2 UTF-16 bytes
-    simdutf::tests::helpers::RandomIntRanges random({//{0x0000, 0xd7ff},
-                                                     {0x00, 0xff}}, 0);
+    simdutf::tests::helpers::RandomIntRanges random({{0x00, 0xff}}, 0);
 
     auto procedure = [&implementation](const char* latin1, size_t size, char16_t* utf16) -> size_t {
       return implementation.convert_latin1_to_utf16le(latin1, size, utf16);

--- a/tests/convert_utf16be_to_latin1_tests.cpp
+++ b/tests/convert_utf16be_to_latin1_tests.cpp
@@ -46,7 +46,7 @@ TEST(convert_2_UTF16_bytes) {
 
 TEST(convert_fails_if_input_too_large) {
   uint32_t seed{1234};
-  simdutf::tests::helpers::RandomInt generator(0xff, 0xffff, seed); //
+  simdutf::tests::helpers::RandomInt generator(0xff, 0xffff, seed);
 
   auto procedure = [&implementation](const char16_t* utf16le, size_t size, char* latin1) -> size_t {
       std::vector<char16_t> utf16be(size);
@@ -54,7 +54,7 @@ TEST(convert_fails_if_input_too_large) {
       return implementation.convert_utf16be_to_latin1(utf16be.data(), size, latin1);
   };
   const size_t size = 64;
-  transcode_utf16_to_latin1_test_base test([](){return '*';}, size+32);
+  transcode_utf16_to_latin1_test_base test([](){ return '*'; }, size+32);
 
   for (size_t j = 0; j < 1000; j++) {
     uint16_t wrong_value = generator();

--- a/tests/convert_utf16be_to_latin1_tests_with_errors.cpp
+++ b/tests/convert_utf16be_to_latin1_tests_with_errors.cpp
@@ -49,7 +49,7 @@ TEST(convert_fails_if_input_too_large) {
   simdutf::tests::helpers::RandomInt generator(0xff, 0xffff, seed);
 
   const size_t size = 64;
-  transcode_utf16_to_latin1_test_base test([](){return '*';}, size+32);
+  transcode_utf16_to_latin1_test_base test([](){ return '*'; }, size+32);
 
   for (size_t j = 0; j < 1000; j++) {
 

--- a/tests/convert_utf16le_to_latin1_tests.cpp
+++ b/tests/convert_utf16le_to_latin1_tests.cpp
@@ -41,13 +41,13 @@ TEST(convert_2_UTF16_bytes) {
 
 TEST(convert_fails_if_input_too_large) {
   uint32_t seed{1234};
-  simdutf::tests::helpers::RandomInt generator(0xff, 0xffff, seed); //
+  simdutf::tests::helpers::RandomInt generator(0xff, 0xffff, seed);
 
   auto procedure = [&implementation](const char16_t* utf16, size_t size, char* latin1) -> size_t {
     return implementation.convert_utf16le_to_latin1(utf16, size, latin1);
   };
   const size_t size = 64;
-  transcode_utf16_to_latin1_test_base test([](){return '*';}, size+32);
+  transcode_utf16_to_latin1_test_base test([](){ return '*'; }, size+32);
 
   for (size_t j = 0; j < 1000; j++) {
     uint16_t wrong_value = generator();

--- a/tests/convert_utf16le_to_latin1_tests_with_errors.cpp
+++ b/tests/convert_utf16le_to_latin1_tests_with_errors.cpp
@@ -43,11 +43,11 @@ TEST(convert_2_UTF16_bytes) {
 
 TEST(convert_fails_if_input_too_large) {
   uint32_t seed{1234};
-  simdutf::tests::helpers::RandomInt generator(0xff, 0xffff, seed); //
+  simdutf::tests::helpers::RandomInt generator(0xff, 0xffff, seed);
 
 
   const size_t size = 64;
-  transcode_utf16_to_latin1_test_base test([](){return '*';}, size+32);
+  transcode_utf16_to_latin1_test_base test([](){ return '*'; }, size+32);
 
   for (size_t j = 0; j < 1000; j++) {
 

--- a/tests/convert_utf32_to_latin1_tests.cpp
+++ b/tests/convert_utf32_to_latin1_tests.cpp
@@ -42,14 +42,14 @@ TEST(convert_fails_if_input_too_large) {
     return implementation.convert_utf32_to_latin1(utf32, size, latin1); 
   };
   const size_t size = 64;
-  simdutf::tests::helpers::transcode_utf32_to_latin1_test_base test([](){return '*';}, size+32); //create an input utf32 and reference latin1 string /w all entries = 0x2a
+  simdutf::tests::helpers::transcode_utf32_to_latin1_test_base test([](){ return '*'; }, size+32); // create an input utf32 and reference latin1 string /w all entries = 0x2a
 
   for (size_t j = 0; j < 1000; j++) {
     uint32_t wrong_value = generator();
     for (size_t i=0; i < size; i++) {
       auto old = test.input_utf32[i];
       test.input_utf32[i] = wrong_value; 
-      ASSERT_TRUE(test(procedure)); //the procedure shouldn't convert anything, so its output should equal the reference string that is all 0x2a
+      ASSERT_TRUE(test(procedure)); // the procedure should not convert anything, so its output should equal the reference string that is all 0x2a
       test.input_utf32[i] = old; 
     }
   }

--- a/tests/convert_utf32_to_latin1_with_errors_tests.cpp
+++ b/tests/convert_utf32_to_latin1_with_errors_tests.cpp
@@ -43,7 +43,7 @@ TEST(convert_fails_if_input_too_large) {
 
 
   const size_t size = 64;
-  simdutf::tests::helpers::transcode_utf32_to_latin1_test_base test([](){return '*';}, size+32);
+  simdutf::tests::helpers::transcode_utf32_to_latin1_test_base test([](){ return '*'; }, size+32);
 
   for (size_t j = 0; j < 1000; j++) {
     uint32_t wrong_value = generator();

--- a/tests/convert_utf8_to_latin1_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_latin1_with_errors_tests.cpp
@@ -101,9 +101,9 @@ auto getUtf8SequenceLength = [](char byte) {
           return 0;
         };
 
-        ASSERT_TRUE(test(procedure)); //no conversion should take place
+        ASSERT_TRUE(test(procedure)); // no conversion should take place
 
-        //does the same as the conditional above: e.g. replace a 4 byte by a '*' ASCII character once its done.
+        // does the same as the conditional above: e.g. replace a 4 byte by a '*' ASCII character once its done.
         for(auto it = test.input_utf8.begin(); it != test.input_utf8.end(); ++it) {
             if(std::distance(it, test.input_utf8.end()) >= byte_number) { 
                 std::fill_n(it, byte_number, 0x2a);
@@ -171,7 +171,7 @@ TEST(too_short_error) {
 
 TEST(too_long_error) {
   uint32_t seed{1234};
-  simdutf::tests::helpers::RandomIntRanges random({{0x7f, 0xff}}, seed);// in this context, conversion to latin 1 will register everything past 0xff as a TOO_LARGE error
+  simdutf::tests::helpers::RandomIntRanges random({{0x7f, 0xff}}, seed); // in this context, conversion to latin 1 will register everything past 0xff as a TOO_LARGE error
   for(size_t trial = 0; trial < trials; trial++) {
     transcode_utf8_to_latin1_test_base test(random, fix_size);
     for (int i = 1; i < fix_size; i++) {

--- a/tests/convert_valid_utf32_to_latin1_tests.cpp
+++ b/tests/convert_valid_utf32_to_latin1_tests.cpp
@@ -19,22 +19,21 @@ namespace {
 TEST(convert_latin1_only) {
   size_t counter = 0;
   auto generator = [&counter]() -> uint32_t {
-    return counter++ & 0xFF; //0x7f;
+    return counter++ & 0xFF; // 0x7f;
   };
 
   auto procedure = [&implementation](const char32_t* utf32, size_t size, char* latin1) -> size_t {
     return implementation.convert_valid_utf32_to_latin1(utf32, size, latin1);
   };
   auto size_procedure = [&implementation](const char32_t* utf32, size_t size) -> size_t {
-    //return implementation.latin1_length_from_utf32(utf32, size); <= this causes a segfault
-    return size; //this does not
+    return implementation.latin1_length_from_utf32(utf32, size);
   };
-  //std::array<size_t, 4> input_size{7,16,24,67};
-  // for (size_t size: input_size) {
+  std::array<size_t, 4> input_size{7,16,24,67};
+  for (size_t size: input_size) {
     simdutf::tests::helpers::transcode_utf32_to_latin1_test_base test(generator, 256);
     ASSERT_TRUE(test(procedure));
-    // ASSERT_TRUE(test.check_size(size_procedure));
-  // }
+    ASSERT_TRUE(test.check_size(size_procedure));
+  }
 }
 
 

--- a/tests/reference/encode_latin1.h
+++ b/tests/reference/encode_latin1.h
@@ -6,10 +6,8 @@ namespace simdutf { namespace tests { namespace reference { namespace latin1 {
 
   // returns whether the value can be represented in the latin1
   bool valid_value(uint32_t value) {
-
-    if (value > 0xFF){return false;}
-
-    return true; //Each possible combination in a bit represent a latin1 value
+    if (value > 0xFF) { return false; }
+    return true; // Each possible combination in a bit represent a latin1 value
   }
 
   // Encodes the value in UTF-32
@@ -17,9 +15,9 @@ namespace simdutf { namespace tests { namespace reference { namespace latin1 {
   // Returns 0 if the value cannot be encoded
   template<typename CONSUMER>
   int encode(uint8_t value, CONSUMER consumer) {
-    if (!valid_value(value))
+    if (!valid_value(value)) {
       return 0;
-      
+    } 
     consumer(value);
     return 1;
   }

--- a/tests/reference/validate_utf8_to_latin1.cpp
+++ b/tests/reference/validate_utf8_to_latin1.cpp
@@ -12,13 +12,13 @@ simdutf_warn_unused bool validate_utf8_to_latin1(const char *buf, size_t len) no
   uint32_t code_point = 0;
   while (pos < len) {
     unsigned char byte = data[pos];
-    if (byte < 0b10000000) {//ASCII
+    if (byte < 0b10000000) { // ASCII
       pos++;
       continue;
-    } else if ((byte & 0b11100000) == 0b11000000) {//two bytes
+    } else if ((byte & 0b11100000) == 0b11000000) { // two bytes
       next_pos = pos + 2;
-      if (next_pos > len) { return false; }//EOF thus no continuation byte :(
-      if ((data[pos + 1] & 0b11000000) != 0b10000000) { //No continuation byte
+      if (next_pos > len) { return false; } // EOF thus no continuation byte :(
+      if ((data[pos + 1] & 0b11000000) != 0b10000000) { // No continuation byte
         return false;
       }
       // range check


### PR DESCRIPTION
Many of these changes are just reformatting, but here are some actual changes.

Some conventions I like:

1. Avoid trailing white space (at the end of a line).
2. Keep indentation uniform (usually just two spaces).
3. Always use curly brackets following in if/then clauses.
4. It is a minor preference, but for code comment, I prefer to avoid contractions (so that it is slightly more formal).


Performance-wise, we want to match ICU and iconv.


Some benchmarking using GCC 11 and an Ice Lake processor. I am excluding haswell and icelake as we shall revisit those later and we should take into account that the westmere code is just the scalar code (although it benefits from autovectorization).

UTF-8 to Latin 1:

```
$ ./benchmarks/benchmark -P convert_utf8_to_latin1 -F ../unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt 
convert_utf8_to_latin1+iconv, input size: 86940, iterations: 3000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
  30.025 ins/byte,    6.250 cycle/byte,    0.511 GB/s (8.1 %),     3.193 GHz,    4.804 ins/cycle 
  30.025 ins/char,    6.250 cycle/char,    0.511 Gc/s (8.1 %)     1.00 byte/char 
convert_utf8_to_latin1+icu, input size: 86940, iterations: 3000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
  14.035 ins/byte,    2.216 cycle/byte,    1.442 GB/s (0.2 %),     3.196 GHz,    6.334 ins/cycle 
  14.035 ins/char,    2.216 cycle/char,    1.442 Gc/s (0.2 %)     1.00 byte/char 
convert_utf8_to_latin1+westmere, input size: 86940, iterations: 3000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
   6.004 ins/byte,    0.628 cycle/byte,    5.103 GB/s (1.3 %),     3.203 GHz,    4.787 ins/cycle 
   3.004 ins/char,    0.628 cycle/char,    5.103 Gc/s (1.3 %)     1.00 byte/char 
convert_utf8_to_latin1_with_errors+westmere, input size: 86940, iterations: 3000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
   3.004 ins/byte,    0.628 cycle/byte,    5.101 GB/s (0.7 %),     3.202 GHz,    4.785 ins/cycle 
   3.004 ins/char,    0.628 cycle/char,    5.101 Gc/s (0.7 %)     1.00 byte/char 
```

UTF-16 to Latin 1

```
$ ./benchmarks/benchmark -P convert_utf16_to_latin1 -F ../unicode_lipsum/lipsum/Latin-Lipsum.utf16.txt

convert_utf16_to_latin1+iconv, input size: 173882, iterations: 3000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf16.txt
  17.013 ins/byte,    3.011 cycle/byte,    1.061 GB/s (25.7 %),     3.194 GHz,    5.651 ins/cycle 
  34.027 ins/char,    6.022 cycle/char,    0.530 Gc/s (25.7 %)     2.00 byte/char 
convert_utf16_to_latin1+icu, input size: 173882, iterations: 3000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf16.txt
   3.468 ins/byte,    0.729 cycle/byte,    4.389 GB/s (1.4 %),     3.201 GHz,    4.755 ins/cycle 
   3.468 ins/char,    0.729 cycle/char,    4.389 Gc/s (1.4 %)     1.00 byte/char 
convert_utf16_to_latin1+westmere, input size: 173882, iterations: 3000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf16.txt
   0.816 ins/byte,    0.228 cycle/byte,   14.118 GB/s (1.2 %),     3.220 GHz,    3.578 ins/cycle 
   0.816 ins/char,    0.228 cycle/char,   14.118 Gc/s (1.2 %)     1.00 byte/char 
convert_utf16_to_latin1_with_errors+westmere, input size: 173882, iterations: 100, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf16.txt
   3.254 ins/byte,    0.737 cycle/byte,    2.716 GB/s (0.8 %),     2.001 GHz,    4.417 ins/cycle 
   3.254 ins/char,    0.737 cycle/char,    2.716 Gc/s (0.8 %)     1.00 byte/char 
```


UTF-32 to Latin 1

```
$ ./benchmarks/benchmark -P convert_utf32_to_latin1 -F ../unicode_lipsum/lipsum/Latin-Lipsum.utf32.txt
convert_utf32_to_latin1+iconv, input size: 347760, iterations: 3000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf32.txt
  10.007 ins/byte,    1.759 cycle/byte,    1.816 GB/s (22.6 %),     3.193 GHz,    5.690 ins/cycle 
  40.028 ins/char,    7.035 cycle/char,    0.454 Gc/s (22.6 %)     4.00 byte/char 
convert_utf32_to_latin1+icu, input size: 347760, iterations: 3000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf32.txt
  78.788 ins/byte,   14.773 cycle/byte,    0.216 GB/s (3.3 %),     3.193 GHz,    5.333 ins/cycle 
  78.788 ins/char,   14.773 cycle/char,    0.216 Gc/s (3.3 %)     1.00 byte/char 
convert_utf32_to_latin1+westmere, input size: 347760, iterations: 3000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf32.txt
   1.629 ins/byte,    0.353 cycle/byte,    9.100 GB/s (1.1 %),     3.215 GHz,    4.610 ins/cycle 
   1.629 ins/char,    0.353 cycle/char,    9.100 Gc/s (1.1 %)     1.00 byte/char 
convert_utf32_to_latin1_with_errors+westmere, input size: 347760, iterations: 3000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf32.txt
   8.003 ins/byte,    1.304 cycle/byte,    2.452 GB/s (7.8 %),     3.198 GHz,    6.138 ins/cycle 
   8.003 ins/char,    1.304 cycle/char,    2.452 Gc/s (7.8 %)     1.00 byte/char 
```

Latin1 to UTF 8

```
$ ./benchmarks/benchmark -P convert_latin1_to_utf8 -F ../unicode_lipsum/wikipedia_mars/german.latin1.txt 
convert_latin1_to_utf8+iconv, input size: 199331, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/german.latin1.txt
  26.201 ins/byte,    6.205 cycle/byte,    0.513 GB/s (42.6 %),     3.185 GHz,    4.223 ins/cycle 
  26.201 ins/char,    6.205 cycle/char,    0.513 Gc/s (42.6 %)     1.00 byte/char 
WARNING: Measurements are noisy, try increasing iteration count (-I).
convert_latin1_to_utf8+icu, input size: 199331, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/german.latin1.txt
  15.878 ins/byte,    3.012 cycle/byte,    1.060 GB/s (1.3 %),     3.193 GHz,    5.271 ins/cycle 
  15.878 ins/char,    3.012 cycle/char,    1.060 Gc/s (1.3 %)     1.00 byte/char 
convert_latin1_to_utf8+westmere, input size: 199331, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/german.latin1.txt
   3.886 ins/byte,    0.853 cycle/byte,    3.745 GB/s (1.7 %),     3.195 GHz,    4.553 ins/cycle 
   3.886 ins/char,    0.853 cycle/char,    3.745 Gc/s (1.7 %)     1.00 byte/char 
```


Latin1 to UTF 16

```
$ ./benchmarks/benchmark -P convert_latin1_to_utf16 -F ../unicode_lipsum/wikipedia_mars/german.latin1.txt 
convert_latin1_to_utf8+iconv, input size: 199331, iterations: 3000, dataset: convert_latin1_to_utf16+iconv, input size: 199331, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/german.latin1.txt
  31.023 ins/byte,    7.013 cycle/byte,    0.455 GB/s (0.6 %),     3.193 GHz,    4.424 ins/cycle 
  31.023 ins/char,    7.013 cycle/char,    0.455 Gc/s (0.6 %)     1.00 byte/char 
convert_latin1_to_utf16+icu, input size: 199331, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/german.latin1.txt
   3.511 ins/byte,    0.612 cycle/byte,    5.222 GB/s (0.5 %),     3.197 GHz,    4.102 ins/cycle 
   2.511 ins/char,    0.612 cycle/char,    5.222 Gc/s (0.5 %)     1.00 byte/char 
convert_latin1_to_utf16+westmere, input size: 199331, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/german.latin1.txt
   0.564 ins/byte,    0.127 cycle/byte,   25.270 GB/s (1.6 %),     3.215 GHz,    4.432 ins/cycle 
   0.564 ins/char,    0.127 cycle/char,   25.270 Gc/s (1.6 %)     1.00 byte/char 
```


Latin1 to UTF 32

```
$ ./benchmarks/benchmark -P convert_latin1_to_utf32 -F ../unicode_lipsum/wikipedia_mars/german.latin1.txt 
convert_latin1_to_utf8+iconv, input size: 199331, iterations: 3000, dataset: convert_latin1_to_utf32+iconv, input size: 199331, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/german.latin1.txt
  32.026 ins/byte,    6.019 cycle/byte,    0.531 GB/s (0.4 %),     3.193 GHz,    5.321 ins/cycle 
  32.026 ins/char,    6.019 cycle/char,    0.531 Gc/s (0.4 %)     1.00 byte/char 
convert_latin1_to_utf32+icu, input size: 199331, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/german.latin1.txt
  54.810 ins/byte,   10.869 cycle/byte,    0.294 GB/s (6.1 %),     3.193 GHz,    5.043 ins/cycle 
  54.810 ins/char,   10.869 cycle/char,    0.294 Gc/s (6.1 %)     1.00 byte/char 
convert_latin1_to_utf32+westmere, input size: 199331, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/german.latin1.txt
   1.126 ins/byte,    0.316 cycle/byte,   10.152 GB/s (2.2 %),     3.207 GHz,    3.566 ins/cycle 
   1.126 ins/char,    0.316 cycle/char,   10.152 Gc/s (2.2 %)     1.00 byte/char 
```

As you can see, we are already quite fast. So it is an excellent basis and if we can beat that, we will be very fast indeed (relatively speaking).